### PR TITLE
Changed ANSI to UTF-8.

### DIFF
--- a/vk_messages/vk_messages.py
+++ b/vk_messages/vk_messages.py
@@ -23,7 +23,7 @@ class MessagesAPI():
     '''
     def __init__(self, login, password, two_factor=False, cookies_save_path=''):
         self.login = login
-        self.password = str(password.encode('ANSI')).replace('\\x', '%')[2:-1]
+        self.password = str(password.encode('UTF-8')).replace('\\x', '%')[2:-1]
         self.two_factor = two_factor
 
         if len(cookies_save_path)!= 0 and cookies_save_path[-1] not in ["/", "\\", '']:


### PR DESCRIPTION
Hello! I have just tried to run your module on Arch Linux and got an error - ANSI is windows-only. Fortunately, there's a one-line change to make things work - the only thing you need is to change encoding to UTF-8. I have successfully logged-in and parsed messages with this change.